### PR TITLE
Metadata Refactor! Files are now chunked.

### DIFF
--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationFileOperations.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationFileOperations.java
@@ -1,6 +1,8 @@
 package foundationdb_fslayer.fdb;
 
 import com.apple.foundationdb.directory.DirectorySubspace;
+import foundationdb_fslayer.fdb.object.Attr;
+
 import java.util.List;
 
 public interface FoundationFileOperations {
@@ -51,4 +53,15 @@ public interface FoundationFileOperations {
    */
   void clearFileContent(String file);
 
+  /**
+   * Creates a new empty file at the given path
+   * returns false on failure
+   */
+  boolean createFile(String path);
+
+
+  /**
+   * Get the attributes of this file or directory
+   */
+  Attr getAttr(String path);
 }

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationFileOperations.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationFileOperations.java
@@ -64,4 +64,9 @@ public interface FoundationFileOperations {
    * Get the attributes of this file or directory
    */
   Attr getAttr(String path);
+
+  /**
+   * Set the time on a file
+   */
+  boolean setFileTime(Long timestamp, String path);
 }

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationFileOperations.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationFileOperations.java
@@ -1,6 +1,5 @@
 package foundationdb_fslayer.fdb;
 
-import com.apple.foundationdb.directory.Directory;
 import com.apple.foundationdb.directory.DirectorySubspace;
 import java.util.List;
 
@@ -24,29 +23,26 @@ public interface FoundationFileOperations {
   /**
    * Remove an empty directory if exists.
    *
-   * @param dir   parent directory
-   * @param paths list of path strings
+   * @param path list of path strings
    * @return a boolean value determining whether removing the directory is successful
    */
-  boolean rmdir(Directory dir, List<String> paths);
+  boolean rmdir(String path);
 
   /**
    * Create a new directory matching the provided path under the given directory.
    *
-   * @param dir   parent directory
-   * @param paths list of path strings
+   * @param path list of path strings
    * @return The directory subspace of the newly created directory
    */
-  DirectorySubspace mkdir(Directory dir, List<String> paths);
+  DirectorySubspace mkdir(String path);
 
   /**
    * List all directories under the provided directory.
    *
-   * @param dir   parent directory
-   * @param paths list of path strings
+   * @param path list of path strings
    * @return a list of strings representing all sub-directories under the current directory
    */
-  List<String> ls(Directory dir, List<String> paths);
+  List<String> ls(String path);
 
   /**
    * Clear content of file

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationFileOperations.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationFileOperations.java
@@ -20,7 +20,7 @@ public interface FoundationFileOperations {
    * @param path file path
    * @param data data to be added to file
    */
-  void write(String path, byte[] data);
+  void write(String path, byte[] data, long offset);
 
   /**
    * Remove an empty directory if exists.
@@ -69,4 +69,6 @@ public interface FoundationFileOperations {
    * Set the time on a file
    */
   boolean setFileTime(Long timestamp, String path);
+
+  int getFileSize(String path);
 }

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationLayer.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationLayer.java
@@ -69,17 +69,11 @@ public class FoundationLayer implements FoundationFileOperations {
 
   @Override
   public List<String> ls(String path) {
-    if ("/".equals(path)){
-      try {
-        return directoryLayer.list(db, new ArrayList<>()).get();
-      } catch (Exception e) {
-        return null;
-      }
+    try {
+      return directoryLayer.list(db, parsePath(path)).get();
+    } catch (Exception e) {
+      return null;
     }
-
-    DirectorySchema dir = new DirectorySchema(path);
-
-    return dbRead(transaction -> dir.list(directoryLayer, transaction));
   }
 
   public void clearFileContent(String filepath) {
@@ -97,10 +91,10 @@ public class FoundationLayer implements FoundationFileOperations {
   public Attr getAttr(String path) {
     List<String> paths = parsePath(path);
     List<String> listDotPath = new ArrayList<>(paths);
-    listDotPath.add(".");
+    listDotPath.add(DirectorySchema.Metadata.META_ROOT);
     ObjectType type = dbRead(rt -> {
       try {
-        DirectorySubspace subspace = directoryLayer.open(rt, paths).get();
+        directoryLayer.open(rt, paths).get();
         return directoryLayer.exists(rt, listDotPath).get() ? ObjectType.DIRECTORY : ObjectType.FILE;
       } catch (Exception e) {return ObjectType.NOT_FOUND; }
     });

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationLayer.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationLayer.java
@@ -57,10 +57,10 @@ public class FoundationLayer implements FoundationFileOperations {
 
 
   @Override
-  public void write(String path, byte[] data) {
+  public void write(String path, byte[] data, long offset) {
     FileSchema file = new FileSchema(path);
 
-    dbWrite(transaction -> file.write(directoryLayer, transaction, data));
+    dbWrite(transaction -> file.write(directoryLayer, transaction, data, offset));
   }
 
 
@@ -106,5 +106,10 @@ public class FoundationLayer implements FoundationFileOperations {
   public boolean setFileTime(Long timestamp, String path) {
     return dbWrite(tr ->
             new FileSchema(path).setTimestamp(directoryLayer, tr, timestamp));
+  }
+
+  @Override
+  public int getFileSize(String path) {
+    return dbRead(rt -> new FileSchema(path).size(directoryLayer, rt));
   }
 }

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/Attr.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/Attr.java
@@ -1,0 +1,14 @@
+package foundationdb_fslayer.fdb.object;
+
+public class Attr {
+    private ObjectType objectType;
+
+    public Attr setObjectType(ObjectType objectType){
+        this.objectType = objectType;
+        return this;
+    }
+
+    public ObjectType getObjectType() {
+        return this.objectType;
+    }
+}

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/Attr.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/Attr.java
@@ -2,6 +2,7 @@ package foundationdb_fslayer.fdb.object;
 
 public class Attr {
     private ObjectType objectType;
+    private Long timestamp;
 
     public Attr setObjectType(ObjectType objectType){
         this.objectType = objectType;
@@ -10,5 +11,14 @@ public class Attr {
 
     public ObjectType getObjectType() {
         return this.objectType;
+    }
+
+    public Attr setTimestamp(Long timestamp){
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    public Long getTimestamp() {
+        return this.timestamp;
     }
 }

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/DirectorySchema.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/DirectorySchema.java
@@ -25,7 +25,14 @@ public class DirectorySchema {
      */
     public List<String> list(Directory dir, ReadTransaction transaction) {
         try {
-            return dir.list(transaction, paths).get();
+            List<String> contents =  dir.list(transaction, paths).get();
+            DirectorySubspace subspace = dir.open(transaction, paths).get();
+            // TODO remove once files are subspaces
+            transaction.getRange(subspace.range()).asList().get().stream()
+                    .map(kv -> Tuple.fromBytes(kv.getKey()))
+                    .map(t -> t.getString(t.size() - 1))
+                    .forEach(contents::add);
+            return contents;
         } catch (Exception e){
             return null;
         }

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/DirectorySchema.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/DirectorySchema.java
@@ -9,7 +9,6 @@ import foundationdb_fslayer.Util;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class DirectorySchema {
     private final List<String> paths;
@@ -28,21 +27,6 @@ public class DirectorySchema {
 
     public static class Metadata {
         public final static String META_ROOT = ".";
-    }
-
-    /**
-     *  Returns the list of file and directory names contained within this directory.
-     *  Will return null if this directory does not exist in the database.
-     */
-    public List<String> list(Directory dir, ReadTransaction transaction) {
-        try {
-            return dir.list(transaction, paths).get().stream()
-                    .filter(str-> !str.equals(Metadata.META_ROOT))
-                    .collect(Collectors.toList());
-        } catch (Exception e){
-            System.err.printf("LS Err %s%n", String.join("/", paths));
-            return null;
-        }
     }
 
     /**

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/DirectorySchema.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/DirectorySchema.java
@@ -4,11 +4,11 @@ import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.directory.Directory;
 import com.apple.foundationdb.directory.DirectorySubspace;
-import com.apple.foundationdb.tuple.Tuple;
 import foundationdb_fslayer.Util;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class DirectorySchema {
     private final List<String> paths;
@@ -20,8 +20,8 @@ public class DirectorySchema {
         paths.add(Metadata.META_ROOT);
     }
 
-    private static class Metadata {
-        final static String META_ROOT = ".";
+    public static class Metadata {
+        public final static String META_ROOT = ".";
     }
 
     /**
@@ -30,8 +30,11 @@ public class DirectorySchema {
      */
     public List<String> list(Directory dir, ReadTransaction transaction) {
         try {
-            return dir.list(transaction, paths).get();
+            return dir.list(transaction, paths).get().stream()
+                    .filter(str-> !str.equals(Metadata.META_ROOT))
+                    .collect(Collectors.toList());
         } catch (Exception e){
+            System.err.printf("LS Err %s%n", String.join("/", paths));
             return null;
         }
     }

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/DirectorySchema.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/DirectorySchema.java
@@ -1,0 +1,59 @@
+package foundationdb_fslayer.fdb.object;
+
+import com.apple.foundationdb.Range;
+import com.apple.foundationdb.ReadTransaction;
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.directory.Directory;
+import com.apple.foundationdb.directory.DirectorySubspace;
+import com.apple.foundationdb.tuple.Tuple;
+import foundationdb_fslayer.Util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DirectorySchema {
+    private final List<String> paths;
+
+    public DirectorySchema(String path){
+        this.paths = Util.parsePath(path);
+    }
+
+    /**
+     *  Returns the list of file and directory names contained within this directory.
+     *  Will return null if this directory does not exist in the database.
+     */
+    public List<String> list(Directory dir, ReadTransaction transaction) {
+        try {
+            return dir.list(transaction, paths).get();
+        } catch (Exception e){
+            return null;
+        }
+    }
+
+    /**
+     *  Attempts to delete this directory from the database.
+     *  Will return false on failure.
+     */
+    public boolean delete(Directory dir, Transaction transaction) {
+        try {
+            dir.removeIfExists(transaction, paths).get();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Creates this directory in the database.
+     * Will return the subspace created, or null if failure occurs.
+     * Will silently succeed if the directory already exists.
+     */
+    public DirectorySubspace create(Directory dir, Transaction transaction) {
+        try {
+            return dir.createOrOpen(transaction, paths).get();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/DirectorySchema.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/DirectorySchema.java
@@ -3,6 +3,7 @@ package foundationdb_fslayer.fdb.object;
 import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.directory.Directory;
+import com.apple.foundationdb.directory.DirectoryLayer;
 import com.apple.foundationdb.directory.DirectorySubspace;
 import foundationdb_fslayer.Util;
 
@@ -18,6 +19,11 @@ public class DirectorySchema {
         this.paths = Util.parsePath(path);
         this.metadataPath = new ArrayList<>(paths);
         paths.add(Metadata.META_ROOT);
+    }
+
+    public Attr getMetadata(DirectoryLayer directoryLayer, ReadTransaction rt) {
+        // TODO
+        return new Attr().setObjectType(ObjectType.DIRECTORY);
     }
 
     public static class Metadata {

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/FileSchema.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/FileSchema.java
@@ -1,0 +1,74 @@
+package foundationdb_fslayer.fdb.object;
+
+import com.apple.foundationdb.ReadTransaction;
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import com.apple.foundationdb.directory.DirectorySubspace;
+import com.google.common.primitives.Bytes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static foundationdb_fslayer.Util.parsePath;
+
+public class FileSchema {
+    private final List<String> path;
+    private final List<String> dirPath; // TODO remove
+    private final String filename; // TODO remove
+
+    public FileSchema(String path) {
+        this.path = parsePath(path);
+        this.filename = this.path.get(this.path.size() - 1);
+        this.dirPath = new ArrayList<>(this.path);
+        this.dirPath.remove(filename);
+    }
+
+    /**
+     * Reads the current value of the file.
+     * Will return null on error.
+     */
+    public byte[] read(DirectoryLayer dir, ReadTransaction transaction){
+        try {
+            DirectorySubspace subspace = dir.open(transaction, dirPath).get();
+            return transaction.get(subspace.pack(filename)).get();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Appends the given bytes to the file.
+     * Returns false if an error occurs.
+     */
+    public boolean write(DirectoryLayer dir, Transaction transaction, byte[] data) {
+        byte[] buffer = read(dir, transaction);
+        byte[] content;
+        if (buffer != null) {
+            content = Bytes.concat(buffer, data);
+        } else {
+            content = data;
+        }
+
+        try {
+            DirectorySubspace subspace = dir.open(transaction, dirPath).get();
+            transaction.set(subspace.pack(filename), content);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Clears the data of this file from the database.
+     * Returns false if an error occurs
+     */
+    public boolean delete(DirectoryLayer directoryLayer, Transaction transaction) {
+        try {
+            DirectorySubspace subspace = directoryLayer.open(transaction, dirPath).get();
+            transaction.clear(subspace.pack(filename));
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/FileSchema.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/FileSchema.java
@@ -118,17 +118,18 @@ public class FileSchema {
     public boolean delete(DirectoryLayer directoryLayer, Transaction transaction) {
         try {
             // Load the chunk space to delete all the chunks
-            DirectorySubspace chunkSpace = directoryLayer.open(transaction, chunksPath).get();
+            DirectorySubspace chunkSpace = directoryLayer.createOrOpen(transaction, chunksPath).get();
             transaction.clear(chunkSpace.range());
             // Delete the chunk space itself
-            chunkSpace.remove(transaction);
+            directoryLayer.removeIfExists(transaction, chunksPath).get();
             // Load the file space to delete the metadata entries
-            DirectorySubspace fileSpace = directoryLayer.open(transaction, path).get();
+            DirectorySubspace fileSpace = directoryLayer.createOrOpen(transaction, path).get();
             transaction.clear(fileSpace.range());
             // Delete the file space itself
-            fileSpace.remove(transaction);
+            directoryLayer.removeIfExists(transaction, path).get();
             return true;
         } catch (Exception e) {
+            e.printStackTrace();
             return false;
         }
     }

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/FileSchema.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/FileSchema.java
@@ -1,26 +1,55 @@
 package foundationdb_fslayer.fdb.object;
 
+import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.directory.DirectoryLayer;
 import com.apple.foundationdb.directory.DirectorySubspace;
-import com.google.common.primitives.Bytes;
+import com.apple.foundationdb.tuple.Tuple;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static foundationdb_fslayer.Util.parsePath;
 
 public class FileSchema {
     private final List<String> path;
-    private final List<String> dirPath; // TODO remove
-    private final String filename; // TODO remove
+    private final List<String> chunksPath;
+
+    private static class Metadata {
+        final static String CHUNKS = "CHUNKS";
+        final static String CHUNK_INFO = "CHUNKINFO";
+        final static String TIMESTAMP = "TIMESTAMP";
+        final static String MODE = "MODE";
+    }
 
     public FileSchema(String path) {
         this.path = parsePath(path);
-        this.filename = this.path.get(this.path.size() - 1);
-        this.dirPath = new ArrayList<>(this.path);
-        this.dirPath.remove(filename);
+        this.chunksPath = new ArrayList<>(this.path);
+        this.chunksPath.add(Metadata.CHUNKS);
+    }
+
+    /**
+     * Create the subspace to store this file
+     * Returns false on error
+     */
+    public boolean create(DirectoryLayer dir, Transaction transaction) {
+        try {
+            // Create the subspace
+            DirectorySubspace fileSpace = dir.create(transaction, path).get();
+            // Create the subspace to store data chunks
+            DirectorySubspace chunkSpace = dir.create(transaction, chunksPath).get();
+            // Initialize chunkInfo file
+            transaction.set(fileSpace.pack(Metadata.CHUNK_INFO), Tuple.fromList(Arrays.asList(0L)).pack());
+            // Initialize empty first chunk
+            transaction.set(chunkSpace.pack(0), new byte[0]);
+
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
     }
 
     /**
@@ -29,8 +58,25 @@ public class FileSchema {
      */
     public byte[] read(DirectoryLayer dir, ReadTransaction transaction){
         try {
-            DirectorySubspace subspace = dir.open(transaction, dirPath).get();
-            return transaction.get(subspace.pack(filename)).get();
+            // Open the file's file & chunk space
+            DirectorySubspace fileSpace = dir.open(transaction, path).get();
+            // Calculate total size of the file
+            Tuple chunkInfo = Tuple.fromBytes(transaction.get(fileSpace.pack(Metadata.CHUNK_INFO)).get());
+            int totalLength = 0;
+            for (int i = 0; i < chunkInfo.size(); ++i){
+                totalLength += chunkInfo.getLong(i);
+            }
+            // Initialize buffer to store file
+            byte[] data = new byte[totalLength];
+            // Grab all the chunks from the database and copy them into the buffer
+            DirectorySubspace chunkSpace = dir.open(transaction, chunksPath).get();
+            int index = 0;
+            for (KeyValue kv: transaction.getRange(chunkSpace.range()).asList().get()) {
+                for (byte b : kv.getValue()) {
+                    data[index++] = b;
+                }
+            }
+            return data;
         } catch (Exception e) {
             return null;
         }
@@ -41,17 +87,24 @@ public class FileSchema {
      * Returns false if an error occurs.
      */
     public boolean write(DirectoryLayer dir, Transaction transaction, byte[] data) {
-        byte[] buffer = read(dir, transaction);
-        byte[] content;
-        if (buffer != null) {
-            content = Bytes.concat(buffer, data);
-        } else {
-            content = data;
-        }
-
         try {
-            DirectorySubspace subspace = dir.open(transaction, dirPath).get();
-            transaction.set(subspace.pack(filename), content);
+            // Check chunk info to know the new chunk to add
+            DirectorySubspace fileSpace = dir.open(transaction, path).get();
+            Tuple chunkInfo = Tuple.fromBytes(transaction.get(fileSpace.pack(Metadata.CHUNK_INFO)).get());
+            int newChunkIndex = chunkInfo.size();
+
+            // Write the new chunk
+            DirectorySubspace chunkSpace = dir.open(transaction, chunksPath).get();
+            transaction.set(chunkSpace.pack(newChunkIndex), data);
+
+            // Update the chunk info
+            List<Long> newChunkInfo = new ArrayList<>();
+            for (int i = 0; i < chunkInfo.size(); ++i){
+                newChunkInfo.add(chunkInfo.getLong(i));
+            }
+            newChunkInfo.add((long) data.length);
+            transaction.set(fileSpace.pack(Metadata.CHUNK_INFO), Tuple.fromList(newChunkInfo).pack());
+
             return true;
         } catch (Exception e) {
             return false;
@@ -64,8 +117,16 @@ public class FileSchema {
      */
     public boolean delete(DirectoryLayer directoryLayer, Transaction transaction) {
         try {
-            DirectorySubspace subspace = directoryLayer.open(transaction, dirPath).get();
-            transaction.clear(subspace.pack(filename));
+            // Load the chunk space to delete all the chunks
+            DirectorySubspace chunkSpace = directoryLayer.open(transaction, chunksPath).get();
+            transaction.clear(chunkSpace.range());
+            // Delete the chunk space itself
+            chunkSpace.remove(transaction);
+            // Load the file space to delete the metadata entries
+            DirectorySubspace fileSpace = directoryLayer.open(transaction, path).get();
+            transaction.clear(fileSpace.range());
+            // Delete the file space itself
+            fileSpace.remove(transaction);
             return true;
         } catch (Exception e) {
             return false;

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/ObjectType.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/ObjectType.java
@@ -1,0 +1,7 @@
+package foundationdb_fslayer.fdb.object;
+
+public enum ObjectType {
+    DIRECTORY,
+    FILE,
+    NOT_FOUND
+}

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fuse/FuseLayer.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fuse/FuseLayer.java
@@ -40,7 +40,7 @@ public class FuseLayer extends FuseStubFS {
     switch (attr.getObjectType()) {
       case FILE:
         stat.st_mode.set(FileStat.S_IFREG | 0777);
-        stat.st_size.set(1000);
+        stat.st_size.set(dbOps.getFileSize(path));
         break;
       case DIRECTORY:
         stat.st_mode.set(FileStat.S_IFDIR | 0755);
@@ -109,7 +109,7 @@ public class FuseLayer extends FuseStubFS {
     byte[] data = new byte[(int) size];
     buf.get(0, data, 0, (int) size);
 
-    dbOps.write(path, data);
+    dbOps.write(path, data, offset);
 
     return (int) size;
   }

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fuse/FuseLayer.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fuse/FuseLayer.java
@@ -4,6 +4,7 @@ import com.apple.foundationdb.directory.DirectoryLayer;
 import foundationdb_fslayer.fdb.FoundationFileOperations;
 import foundationdb_fslayer.fdb.object.Attr;
 import jnr.ffi.Pointer;
+import jnr.ffi.types.time_t;
 import ru.serce.jnrfuse.ErrorCodes;
 import ru.serce.jnrfuse.FuseFillDir;
 import ru.serce.jnrfuse.FuseStubFS;
@@ -120,7 +121,7 @@ public class FuseLayer extends FuseStubFS {
 
   @Override
   public int utimens(String path, Timespec[] timespec) {
-    return 0;
+    return dbOps.setFileTime(timespec[0].tv_sec.get(), path) ? 0 : -ErrorCodes.ENOENT();
   }
 
   @Override

--- a/fslayer/app/src/test/java/foundationdb_fslayer/fdbTest.java
+++ b/fslayer/app/src/test/java/foundationdb_fslayer/fdbTest.java
@@ -49,6 +49,7 @@ public class fdbTest {
   @Test
   public void testClearFileContent() {
     // Create a file to delete
+    fsLayer.createFile("/junit_test/delete_me");
     fsLayer.write("/junit_test/delete_me", new byte[1]);
 
     // Delete the file
@@ -62,6 +63,7 @@ public class fdbTest {
   public void testWrite() {
     // create new file
     String filePath = "/junit_test/file";
+    fsLayer.createFile(filePath);
 
     // Write to file
     String startPhrase = "start writing to file";
@@ -107,7 +109,9 @@ public class fdbTest {
     // Create some files
     List<String> filenames = Arrays.asList("a.txt", "b.png", "c.mp4");
     for (String filename : filenames) {
-      fsLayer.write(testPath + "/" + filename, new byte[1]);
+      String filepath = testPath + "/" + filename;
+      fsLayer.createFile(filepath);
+      fsLayer.write(filepath, new byte[1]);
     }
 
     // Call ls

--- a/fslayer/app/src/test/java/foundationdb_fslayer/fdbTest.java
+++ b/fslayer/app/src/test/java/foundationdb_fslayer/fdbTest.java
@@ -1,18 +1,12 @@
 package foundationdb_fslayer;
 
-import com.apple.foundationdb.directory.Directory;
-import com.apple.foundationdb.directory.DirectoryLayer;
-import com.apple.foundationdb.directory.DirectorySubspace;
-import com.apple.foundationdb.tuple.Tuple;
 import foundationdb_fslayer.fdb.FoundationFileOperations;
 import foundationdb_fslayer.fdb.FoundationLayer;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -21,26 +15,22 @@ import static org.junit.Assert.*;
 public class fdbTest {
 
   private FoundationFileOperations fsLayer;
-  private Directory dir;
-  private List<String> testDirPath;
+  private static final String testPath = "/junit_test";
 
   @Before
   public void setup() {
     fsLayer = new FoundationLayer(630);
-    dir = new DirectoryLayer();
-    testDirPath = new ArrayList<>();
-    testDirPath.add("junit_test");
   }
 
   @BeforeEach
   public void prepareTest() {
-    fsLayer.rmdir(dir, testDirPath);
-    fsLayer.mkdir(dir, testDirPath);
+    fsLayer.rmdir(testPath);
+    fsLayer.mkdir(testPath);
   }
 
   @AfterEach
   public void cleanup() {
-    fsLayer.rmdir(dir, testDirPath);
+    fsLayer.rmdir(testPath);
   }
 
   @Test
@@ -91,20 +81,19 @@ public class fdbTest {
   @Test
   public void testRmdir() {
     // Verify deletion is successful
-    assertTrue(fsLayer.rmdir(dir, testDirPath));
+    assertTrue(fsLayer.rmdir(testPath));
     // Verify the directory is actually deleted
-    assertNull(fsLayer.ls(dir, testDirPath));
+    assertNull(fsLayer.ls(testPath));
   }
 
   @Test
   public void testMkdir() {
     // Create a new directory
-    List<String> newPath = new ArrayList<>(testDirPath);
-    newPath.add("mkdir");
-    fsLayer.mkdir(dir, newPath);
+    String newPath = testPath + "/mkdir";
+    fsLayer.mkdir(newPath);
 
     // Verify the new directory exists
-    assertNotNull(fsLayer.ls(dir, newPath));
+    assertNotNull(fsLayer.ls(newPath));
   }
 
   @Test
@@ -112,19 +101,17 @@ public class fdbTest {
     // Create some subdirectories
     List<String> subDirNames = Arrays.asList("alpha", "bravo", "charlie");
     for (String subDirName : subDirNames){
-      List<String> path = new ArrayList<>(testDirPath);
-      path.add(subDirName);
-      fsLayer.mkdir(dir, path);
+      fsLayer.mkdir(testPath + "/" + subDirName);
     }
 
     // Create some files
     List<String> filenames = Arrays.asList("a.txt", "b.png", "c.mp4");
     for (String filename : filenames) {
-      fsLayer.write("/junit_test/" + filename, new byte[1]);
+      fsLayer.write(testPath + "/" + filename, new byte[1]);
     }
 
     // Call ls
-    List<String> lsOut = fsLayer.ls(dir, testDirPath);
+    List<String> lsOut = fsLayer.ls(testPath);
 
     // Verify all the created items are present
     filenames.forEach(filename -> assertTrue(lsOut.contains(filename)));

--- a/fslayer/app/src/test/java/foundationdb_fslayer/fdbTest.java
+++ b/fslayer/app/src/test/java/foundationdb_fslayer/fdbTest.java
@@ -36,6 +36,7 @@ public class fdbTest {
   @Test
   public void testRead() {
     // Write some data to test read
+    fsLayer.createFile("/junit_test/hello");
     fsLayer.write("/junit_test/hello", "world".getBytes());
 
     // Assert the read is correct

--- a/fslayer/app/src/test/java/foundationdb_fslayer/fdbTest.java
+++ b/fslayer/app/src/test/java/foundationdb_fslayer/fdbTest.java
@@ -37,7 +37,7 @@ public class fdbTest {
   public void testRead() {
     // Write some data to test read
     fsLayer.createFile("/junit_test/hello");
-    fsLayer.write("/junit_test/hello", "world".getBytes());
+    fsLayer.write("/junit_test/hello", "world".getBytes(), 0);
 
     // Assert the read is correct
     assertEquals("world", new String(fsLayer.read("/junit_test/hello")));
@@ -51,7 +51,7 @@ public class fdbTest {
   public void testClearFileContent() {
     // Create a file to delete
     fsLayer.createFile("/junit_test/delete_me");
-    fsLayer.write("/junit_test/delete_me", new byte[1]);
+    fsLayer.write("/junit_test/delete_me", new byte[1], 0);
 
     // Delete the file
     fsLayer.clearFileContent("/junit_test/delete_me");
@@ -68,13 +68,14 @@ public class fdbTest {
 
     // Write to file
     String startPhrase = "start writing to file";
-    fsLayer.write(filePath, startPhrase.getBytes(StandardCharsets.UTF_8));
+    byte[] startPhraseBytes = startPhrase.getBytes(StandardCharsets.UTF_8);
+    fsLayer.write(filePath, startPhraseBytes, 0);
     // Verify the output
     assertEquals(startPhrase, new String(fsLayer.read(filePath)));
 
     // continue writing to file
     String continuePhrase = " Continue writing to file";
-    fsLayer.write(filePath, continuePhrase.getBytes(StandardCharsets.UTF_8));
+    fsLayer.write(filePath, continuePhrase.getBytes(StandardCharsets.UTF_8), startPhraseBytes.length);
     String fileContent = startPhrase + continuePhrase;
     // Verify the new string has been appended
     assertEquals(fileContent, new String(fsLayer.read(filePath)));
@@ -112,7 +113,7 @@ public class fdbTest {
     for (String filename : filenames) {
       String filepath = testPath + "/" + filename;
       fsLayer.createFile(filepath);
-      fsLayer.write(filepath, new byte[1]);
+      fsLayer.write(filepath, new byte[1],0);
     }
 
     // Call ls


### PR DESCRIPTION
This PR does a few things:
- Create dedicated File and Directory classes to handle their respective operations
- Makes file a FoundationDB DirectorySubspace instead of a key
- Stores the size of each chunk in /path/to/file/CHUNKINFO
- Read now grabs the data in every chunk listed in CHUNKINFO
- Write will now just throw all the new data into a new chunk (this will need to change for obvious efficiency reasons)
- Stores chunks in path/to/file/CHUNK/<chunk-index>
- Directories now have hidden sub-directory /path/to/dir/. to hold future metadata