### PR TITLE
Implement file cache

### DIFF
--- a/fslayer/app/src/main/java/foundationdb_fslayer/App.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/App.java
@@ -17,6 +17,8 @@ public class App {
     FoundationFileOperations dbOps = new FoundationLayer(630);
     FuseLayer fuseLayer = new FuseLayer(dbOps);
 
+    dbOps.initRootIfNeeded();
+
     try {
       fuseLayer.mount(Paths.get(args[0]), true, true);
     } finally {

--- a/fslayer/app/src/main/java/foundationdb_fslayer/cache/DirectoryCacheEntry.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/cache/DirectoryCacheEntry.java
@@ -16,27 +16,25 @@ public class DirectoryCacheEntry {
     private DirectoryCacheEntry() {}
 
     public static DirectoryCacheEntry loadFromDB(
+            List<String> children,
             DirectorySchema schema,
             DirectoryLayer directoryLayer,
             ReadTransaction rt) {
         DirectoryCacheEntry entry = new DirectoryCacheEntry();
         entry.schema = schema;
-        return entry.reload(directoryLayer, rt);
+        return entry.reload(directoryLayer, rt, children);
     }
 
-    public DirectoryCacheEntry reload(DirectoryLayer directoryLayer, ReadTransaction rt) {
+    public DirectoryCacheEntry reload(DirectoryLayer directoryLayer, ReadTransaction rt, List<String> children) {
         this.version = schema.getVersion(directoryLayer, rt);
         this.metadata = schema.loadMetadata(directoryLayer, rt);
-        this.children = schema.loadChildren(directoryLayer, rt);
+        this.children = children;
 
         return this;
     }
 
-    public DirectoryCacheEntry reloadIfOutdated(DirectoryLayer directoryLayer, ReadTransaction readTransaction) {
-        if (schema.getVersion(directoryLayer, readTransaction) != version) {
-            return this.reload(directoryLayer, readTransaction);
-        }
-        return this;
+    public boolean isCurrent(DirectoryLayer directoryLayer, ReadTransaction rt)  {
+        return this.version == schema.getVersion(directoryLayer, rt);
     }
 
     public long getVersion() {

--- a/fslayer/app/src/main/java/foundationdb_fslayer/cache/DirectoryCacheEntry.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/cache/DirectoryCacheEntry.java
@@ -1,0 +1,53 @@
+package foundationdb_fslayer.cache;
+
+import com.apple.foundationdb.ReadTransaction;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import foundationdb_fslayer.fdb.object.Attr;
+import foundationdb_fslayer.fdb.object.DirectorySchema;
+
+import java.util.List;
+
+public class DirectoryCacheEntry {
+    private long version;
+    private DirectorySchema schema;
+    private Attr metadata;
+    private List<String> children;
+
+    private DirectoryCacheEntry() {}
+
+    public static DirectoryCacheEntry loadFromDB(
+            DirectorySchema schema,
+            DirectoryLayer directoryLayer,
+            ReadTransaction rt) {
+        DirectoryCacheEntry entry = new DirectoryCacheEntry();
+        entry.schema = schema;
+        return entry.reload(directoryLayer, rt);
+    }
+
+    public DirectoryCacheEntry reload(DirectoryLayer directoryLayer, ReadTransaction rt) {
+        this.version = schema.getVersion(directoryLayer, rt);
+        this.metadata = schema.loadMetadata(directoryLayer, rt);
+        this.children = schema.loadChildren(directoryLayer, rt);
+
+        return this;
+    }
+
+    public DirectoryCacheEntry reloadIfOutdated(DirectoryLayer directoryLayer, ReadTransaction readTransaction) {
+        if (schema.getVersion(directoryLayer, readTransaction) != version) {
+            return this.reload(directoryLayer, readTransaction);
+        }
+        return this;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public Attr getMetadata() {
+        return metadata;
+    }
+
+    public List<String> getChildren() {
+        return children;
+    }
+}

--- a/fslayer/app/src/main/java/foundationdb_fslayer/cache/FileCacheEntry.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/cache/FileCacheEntry.java
@@ -31,7 +31,7 @@ public class FileCacheEntry {
 
     public FileCacheEntry reload(DirectoryLayer directoryLayer, ReadTransaction rt){
         this.version = schema.getVersion(directoryLayer, rt);
-        this.metadata = schema.getMetadata(directoryLayer, rt);
+        this.metadata = schema.loadMetadata(directoryLayer, rt);
         this.data = schema.loadChunks(directoryLayer, rt);
         return this;
     }

--- a/fslayer/app/src/main/java/foundationdb_fslayer/cache/FileCacheEntry.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/cache/FileCacheEntry.java
@@ -1,0 +1,69 @@
+package foundationdb_fslayer.cache;
+
+import com.apple.foundationdb.ReadTransaction;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import foundationdb_fslayer.fdb.object.Attr;
+import foundationdb_fslayer.fdb.object.FileSchema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FileCacheEntry {
+    private List<byte[]> data;
+    private Attr metadata;
+    private long version;
+    private FileSchema schema;
+
+    private FileCacheEntry() {}
+
+    public static FileCacheEntry loadFromDB(
+            FileSchema schema,
+            DirectoryLayer directoryLayer,
+            ReadTransaction rt) {
+        FileCacheEntry entry = new FileCacheEntry();
+        entry.schema = schema;
+        return entry.reload(directoryLayer, rt);
+    }
+
+    public boolean isCurrent(DirectoryLayer directoryLayer, ReadTransaction rt) {
+        return this.version == this.schema.getVersion(directoryLayer, rt);
+    }
+
+    public FileCacheEntry reload(DirectoryLayer directoryLayer, ReadTransaction rt){
+        this.version = schema.getVersion(directoryLayer, rt);
+        this.metadata = schema.getMetadata(directoryLayer, rt);
+        this.data = schema.loadChunks(directoryLayer, rt);
+        return this;
+    }
+
+    public FileCacheEntry reloadIfOutdated(DirectoryLayer directoryLayer, ReadTransaction rt) {
+        if (isCurrent(directoryLayer, rt)) {
+            return this;
+        }
+        return this.reload(directoryLayer, rt);
+    }
+
+    public byte[] getData(int chunkIndex) {
+        if (chunkIndex < data.size()) {
+            return data.get(chunkIndex);
+        } else {
+            return new byte[0];
+        }
+    }
+
+    public List<byte[]> getData(int startIndex, int endIndex) {
+        List<byte[]> splice = new ArrayList<>();
+        for (int i = startIndex; i <= endIndex && i < data.size(); ++i) {
+            splice.add(data.get(i));
+        }
+        return splice;
+    }
+
+    public List<byte[]> getData() {
+        return this.data;
+    }
+
+    public Attr getMetadata() {
+        return metadata;
+    }
+}

--- a/fslayer/app/src/main/java/foundationdb_fslayer/cache/FsCacheSingleton.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/cache/FsCacheSingleton.java
@@ -1,0 +1,29 @@
+package foundationdb_fslayer.cache;
+
+import com.apple.foundationdb.ReadTransaction;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import foundationdb_fslayer.fdb.object.FileSchema;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+public class FsCacheSingleton {
+    private static final HashMap<String, FileCacheEntry> FILE_CACHE = new HashMap<>();
+
+    public static void loadToCache(String path, DirectoryLayer directoryLayer, ReadTransaction rt) {
+        FileSchema schema = new FileSchema(path);
+        FILE_CACHE.put(path, FileCacheEntry.loadFromDB(schema, directoryLayer, rt));
+    }
+
+    public static void removeFromCache(String path) {
+        FILE_CACHE.remove(path);
+    }
+
+    public static Optional<FileCacheEntry> getFile(String path) {
+        return Optional.ofNullable(FILE_CACHE.getOrDefault(path, null));
+    }
+
+    public static boolean inCache(String path) {
+        return FILE_CACHE.containsKey(path);
+    }
+}

--- a/fslayer/app/src/main/java/foundationdb_fslayer/cache/FsCacheSingleton.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/cache/FsCacheSingleton.java
@@ -6,6 +6,7 @@ import foundationdb_fslayer.fdb.object.DirectorySchema;
 import foundationdb_fslayer.fdb.object.FileSchema;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 
 public class FsCacheSingleton {
@@ -29,9 +30,9 @@ public class FsCacheSingleton {
         return FILE_CACHE.containsKey(path);
     }
 
-    public static void loadDirToCache(String path, DirectoryLayer directoryLayer, ReadTransaction rt) {
-        DirectorySchema schama = new DirectorySchema(path);
-        DIR_CACHE.put(path, DirectoryCacheEntry.loadFromDB(schama, directoryLayer, rt));
+    public static void loadDirToCache(String path, DirectoryLayer directoryLayer, ReadTransaction rt, List<String> children) {
+        DirectorySchema schema = new DirectorySchema(path);
+        DIR_CACHE.put(path, DirectoryCacheEntry.loadFromDB(children, schema, directoryLayer, rt));
     }
 
     public static void removeDirFromCache(String path) {

--- a/fslayer/app/src/main/java/foundationdb_fslayer/cache/FsCacheSingleton.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/cache/FsCacheSingleton.java
@@ -2,6 +2,7 @@ package foundationdb_fslayer.cache;
 
 import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.directory.DirectoryLayer;
+import foundationdb_fslayer.fdb.object.DirectorySchema;
 import foundationdb_fslayer.fdb.object.FileSchema;
 
 import java.util.HashMap;
@@ -9,13 +10,14 @@ import java.util.Optional;
 
 public class FsCacheSingleton {
     private static final HashMap<String, FileCacheEntry> FILE_CACHE = new HashMap<>();
+    private static final HashMap<String, DirectoryCacheEntry> DIR_CACHE = new HashMap<>();
 
-    public static void loadToCache(String path, DirectoryLayer directoryLayer, ReadTransaction rt) {
+    public static void loadFileToCache(String path, DirectoryLayer directoryLayer, ReadTransaction rt) {
         FileSchema schema = new FileSchema(path);
         FILE_CACHE.put(path, FileCacheEntry.loadFromDB(schema, directoryLayer, rt));
     }
 
-    public static void removeFromCache(String path) {
+    public static void removeFileFromCache(String path) {
         FILE_CACHE.remove(path);
     }
 
@@ -23,7 +25,24 @@ public class FsCacheSingleton {
         return Optional.ofNullable(FILE_CACHE.getOrDefault(path, null));
     }
 
-    public static boolean inCache(String path) {
+    public static boolean fileInCache(String path) {
         return FILE_CACHE.containsKey(path);
+    }
+
+    public static void loadDirToCache(String path, DirectoryLayer directoryLayer, ReadTransaction rt) {
+        DirectorySchema schama = new DirectorySchema(path);
+        DIR_CACHE.put(path, DirectoryCacheEntry.loadFromDB(schama, directoryLayer, rt));
+    }
+
+    public static void removeDirFromCache(String path) {
+        DIR_CACHE.remove(path);
+    }
+
+    public static boolean dirInCache(String path) {
+        return DIR_CACHE.containsKey(path);
+    }
+
+    public static Optional<DirectoryCacheEntry> getDir(String path) {
+        return Optional.ofNullable(DIR_CACHE.getOrDefault(path, null));
     }
 }

--- a/fslayer/app/src/main/java/foundationdb_fslayer/cache/FsCacheSingleton.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/cache/FsCacheSingleton.java
@@ -30,9 +30,10 @@ public class FsCacheSingleton {
         return FILE_CACHE.containsKey(path);
     }
 
-    public static void loadDirToCache(String path, DirectoryLayer directoryLayer, ReadTransaction rt, List<String> children) {
+    public static DirectoryCacheEntry loadDirToCache(String path, DirectoryLayer directoryLayer, ReadTransaction rt, List<String> children) {
         DirectorySchema schema = new DirectorySchema(path);
         DIR_CACHE.put(path, DirectoryCacheEntry.loadFromDB(children, schema, directoryLayer, rt));
+        return DIR_CACHE.get(path);
     }
 
     public static void removeDirFromCache(String path) {

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationFileOperations.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationFileOperations.java
@@ -102,4 +102,6 @@ public interface FoundationFileOperations {
   boolean chown(String path, long uid, long gid);
 
   int open(String path, int flags);
+
+  void initRootIfNeeded();
 }

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationLayer.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationLayer.java
@@ -3,6 +3,7 @@ package foundationdb_fslayer.fdb;
 import com.apple.foundationdb.*;
 import com.apple.foundationdb.directory.DirectoryLayer;
 import com.apple.foundationdb.directory.DirectorySubspace;
+import foundationdb_fslayer.cache.DirectoryCacheEntry;
 import foundationdb_fslayer.cache.FsCacheSingleton;
 import foundationdb_fslayer.fdb.object.Attr;
 import foundationdb_fslayer.fdb.object.DirectorySchema;
@@ -10,7 +11,9 @@ import foundationdb_fslayer.fdb.object.FileSchema;
 import foundationdb_fslayer.fdb.object.ObjectType;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static foundationdb_fslayer.Util.parsePath;
@@ -67,11 +70,29 @@ public class FoundationLayer implements FoundationFileOperations {
 
   @Override
   public List<String> ls(String path) {
-    try {
-      return directoryLayer.list(db, parsePath(path)).get();
-    } catch (Exception e) {
-      return null;
-    }
+    Optional<List<String>> cacheValue = dbRead(rt ->
+            FsCacheSingleton.getDir(path).flatMap(entry ->
+                    entry.isCurrent(directoryLayer, rt)
+                            ? Optional.of(entry.getChildren())
+                            : Optional.empty()));
+    return cacheValue.orElseGet(() -> {
+      try {
+        List<String> children = directoryLayer.list(db, parsePath(path)).get();
+        if (!FsCacheSingleton.dirInCache(path)) {
+          dbRead(rt -> {
+            FsCacheSingleton.loadDirToCache(path, directoryLayer, rt, children);
+            return null;
+          });
+        } else {
+          DirectoryCacheEntry entry = FsCacheSingleton.getDir(path)
+                  .orElseThrow(() -> new IllegalStateException("Dir not present after check"));
+          dbRead(rt -> entry.reload(directoryLayer, rt, children));
+        }
+        return children;
+      } catch (Exception e) {
+        return null;
+      }
+    });
   }
 
   public void clearFileContent(String filepath) {
@@ -133,5 +154,23 @@ public class FoundationLayer implements FoundationFileOperations {
   @Override
   public int open(String path, int flags) {
     return dbWrite(tr -> new FileSchema(path).open(directoryLayer, tr, flags));
+  }
+
+  @Override
+  public void initRootIfNeeded() {
+    db.run(tr -> {
+      try {
+        if (!directoryLayer.exists(tr, Arrays.asList(DirectorySchema.Metadata.META_ROOT)).get()) {
+          new DirectorySchema("/").initMetadata(directoryLayer, tr);
+          System.out.println("Root directory created!");
+        } else {
+          System.out.println("Root directory exists!");
+        }
+      } catch (Exception e) {
+        System.err.println("Error checking if meta root exists to initialize");
+        e.printStackTrace();
+      }
+      return null;
+    });
   }
 }

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationLayer.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/FoundationLayer.java
@@ -3,6 +3,7 @@ package foundationdb_fslayer.fdb;
 import com.apple.foundationdb.*;
 import com.apple.foundationdb.directory.DirectoryLayer;
 import com.apple.foundationdb.directory.DirectorySubspace;
+import foundationdb_fslayer.cache.FsCacheSingleton;
 import foundationdb_fslayer.fdb.object.Attr;
 import foundationdb_fslayer.fdb.object.DirectorySchema;
 import foundationdb_fslayer.fdb.object.FileSchema;

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/AbstractSchema.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/AbstractSchema.java
@@ -24,6 +24,12 @@ abstract public class AbstractSchema {
         String path = getPath();
         String parentPath = path.substring(0, path.lastIndexOf("/"));
 
+        if (parentPath.equals("")) {
+            parentPath = "/";
+        }
+
+        System.out.println("ATTEMPTING TO INCREMENT VERSION OF " + parentPath);
+
         new DirectorySchema(parentPath).incrementVersion(dir, tr);
     }
 

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/AbstractSchema.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/AbstractSchema.java
@@ -1,0 +1,48 @@
+package foundationdb_fslayer.fdb.object;
+
+import com.apple.foundationdb.ReadTransaction;
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import com.apple.foundationdb.directory.DirectorySubspace;
+import com.apple.foundationdb.tuple.Tuple;
+
+import java.util.ArrayList;
+import java.util.List;
+
+abstract public class AbstractSchema {
+    protected abstract String getPath();
+
+    protected abstract DirectorySubspace getMetadataSpace(DirectoryLayer directoryLayer, ReadTransaction rt);
+
+    protected abstract String getVersionKey();
+
+    /**
+     * Increments the read version of the directory above this file or directory
+     * Called on create / delete to update cached list of children
+     */
+    public void incrementParentVersion(DirectoryLayer dir, Transaction tr) {
+        String path = getPath();
+        String parentPath = path.substring(0, path.lastIndexOf("/"));
+
+        new DirectorySchema(parentPath).incrementVersion(dir, tr);
+    }
+
+    public long getVersion(DirectoryLayer directoryLayer, ReadTransaction rt) {
+        try {
+            return Tuple.fromBytes(rt.get(getMetadataSpace(directoryLayer, rt).pack(getVersionKey())).get())
+                    .getLong(0);
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+
+    public long incrementVersion(DirectoryLayer directoryLayer, Transaction tr) {
+        long currentVersion = getVersion(directoryLayer, tr);
+        try {
+            tr.set(getMetadataSpace(directoryLayer, tr).pack(getVersionKey()), Tuple.from(currentVersion + 1).pack());
+            return currentVersion + 1;
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+}

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/DirectorySchema.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/DirectorySchema.java
@@ -5,38 +5,70 @@ import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.directory.Directory;
 import com.apple.foundationdb.directory.DirectoryLayer;
 import com.apple.foundationdb.directory.DirectorySubspace;
+import com.apple.foundationdb.tuple.Tuple;
 import foundationdb_fslayer.Util;
+import foundationdb_fslayer.cache.DirectoryCacheEntry;
+import foundationdb_fslayer.cache.FsCacheSingleton;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
-public class DirectorySchema {
+public class DirectorySchema extends AbstractSchema{
     private final List<String> paths;
     private final List<String> metadataPath;
+    private String rawPath;
 
     public DirectorySchema(String path){
+        this.rawPath = path;
         this.paths = Util.parsePath(path);
         this.metadataPath = new ArrayList<>(paths);
         paths.add(Metadata.META_ROOT);
     }
 
     public Attr getMetadata(DirectoryLayer directoryLayer, ReadTransaction rt) {
+        return loadCache(directoryLayer, rt).getMetadata();
+    }
+
+    public Attr loadMetadata(DirectoryLayer directoryLayer, ReadTransaction rt) {
         // TODO
         return new Attr().setObjectType(ObjectType.DIRECTORY);
     }
 
+    @Override
+    protected String getPath() {
+        return rawPath;
+    }
+
+    @Override
+    protected DirectorySubspace getMetadataSpace(DirectoryLayer directoryLayer, ReadTransaction rt) {
+        try {
+            return directoryLayer.open(rt, metadataPath).get();
+        } catch (Exception e) {
+            throw new IllegalStateException("Ahhhh");
+        }
+    }
+
+    @Override
+    protected String getVersionKey() {
+        return Metadata.VERSION;
+    }
+
     public static class Metadata {
         public final static String META_ROOT = ".";
+        public final static String VERSION = "VERSION";
     }
 
     /**
      *  Attempts to delete this directory from the database.
      *  Will return false on failure.
      */
-    public boolean delete(Directory dir, Transaction transaction) {
+    public boolean delete(DirectoryLayer dir, Transaction transaction) {
         try {
             dir.removeIfExists(transaction, paths).get();
+            transaction.clear(getMetadataSpace(dir, transaction).range());
             dir.removeIfExists(transaction, metadataPath).get();
+            incrementParentVersion(dir, transaction);
             return true;
         } catch (Exception e) {
             return false;
@@ -48,15 +80,43 @@ public class DirectorySchema {
      * Will return the subspace created, or null if failure occurs.
      * Will silently succeed if the directory already exists.
      */
-    public DirectorySubspace create(Directory dir, Transaction transaction) {
+    public DirectorySubspace create(DirectoryLayer dir, Transaction transaction) {
         try {
             // Create this directory
             DirectorySubspace subspace =  dir.createOrOpen(transaction, paths).get();
             // Create internal metadata subspace
-            dir.createOrOpen(transaction, metadataPath).get();
+            DirectorySubspace metaSpace = dir.createOrOpen(transaction, metadataPath).get();
+            // Initialize the directory's write version
+            transaction.set(metaSpace.pack(Metadata.VERSION), Tuple.from(0).pack());
+            incrementParentVersion(dir, transaction);
             return subspace;
         } catch (Exception e) {
             return null;
         }
+    }
+
+    public List<String> loadChildren(DirectoryLayer directoryLayer, ReadTransaction rt) {
+        try {
+            return directoryLayer.list(rt, paths).get();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public List<String> ls(DirectoryLayer dir, ReadTransaction rt) {
+        return loadCache(dir, rt).getChildren();
+    }
+
+    private DirectoryCacheEntry loadCache(DirectoryLayer directoryLayer, ReadTransaction readTransaction) {
+        if (!FsCacheSingleton.dirInCache(this.rawPath)) {
+            FsCacheSingleton.loadDirToCache(this.rawPath, directoryLayer, readTransaction);
+        }
+
+        Optional<DirectoryCacheEntry> entry = FsCacheSingleton.getDir(rawPath);
+
+        if (!entry.isPresent()) {
+            throw new IllegalStateException("Dir not present in cache after load");
+        }
+        return entry.get().reloadIfOutdated(directoryLayer, readTransaction);
     }
 }

--- a/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/DirectorySchema.java
+++ b/fslayer/app/src/main/java/foundationdb_fslayer/fdb/object/DirectorySchema.java
@@ -25,11 +25,6 @@ public class DirectorySchema extends AbstractSchema{
         metadataPath.add(Metadata.META_ROOT);
     }
 
-    public Attr getMetadata(DirectoryLayer directoryLayer, ReadTransaction rt) {
-        // TODO pass the cache entry to this method so it can be reloaded at the FoundationLayer
-        return this.loadMetadata(directoryLayer, rt);
-    }
-
     public Attr loadMetadata(DirectoryLayer directoryLayer, ReadTransaction rt) {
         // TODO
         return new Attr().setObjectType(ObjectType.DIRECTORY);


### PR DESCRIPTION
Instead of incrementing version on open, increment on write & truncate.

The singleton class FsCacheSingleton has static methods allowing the retrieval of cached info. In FileSchema, anywhere that data is read from the database, we instead grab the cached info (reloading if the cached version does not match). 